### PR TITLE
[JCR importer] support page image

### DIFF
--- a/test/importers/html2jcr/fixtures/block-element-grouping.expected.xml
+++ b/test/importers/html2jcr/fixtures/block-element-grouping.expected.xml
@@ -12,5 +12,6 @@
                 <block_0 sling:resourceType="core/franklin/components/block/v1/block" jcr:primaryType="nt:unstructured" name="Image Grouping" teaser_image="/content/dam/teaser-background.png" teaser_imageMimeType="image/unknown" teaser_cta1="https://link.to/more-details" teaser_cta1Text="More Details" teaser_cta1Title="Link to details" model="image-grouping"/>
             </section>
         </root>
+        <image jcr:primaryType="nt:unstructured" fileReference="https://main--xwalk-example--buuhuu.hlx.page/media_134b848c697e9152f269fa3b79696b855040912ba.png?width=1200&amp;format=pjpg&amp;optimize=medium"/>
     </jcr:content>
 </jcr:root>

--- a/test/importers/html2jcr/fixtures/block-field-collapsing.expected.xml
+++ b/test/importers/html2jcr/fixtures/block-field-collapsing.expected.xml
@@ -6,5 +6,6 @@
                 <block sling:resourceType="core/franklin/components/block/v1/block" jcr:primaryType="nt:unstructured" name="Teaser" image="/content/dam/teaser-background.png" imageAlt="A group of people sitting on a stage &amp; relaxing" title="Meet the Experts" titleType="h2" link="https://www.adobe.com" linkType="secondary" linkText="Secondary Button" linkTitle="This is a Secondary Button" model="teaser"/>
             </section>
         </root>
+        <image jcr:primaryType="nt:unstructured" fileReference="https://main--xwalk-example--buuhuu.hlx.page/media_134b848c697e9152f269fa3b79696b855040912ba.png?width=1200&amp;format=pjpg&amp;optimize=medium"/>
     </jcr:content>
 </jcr:root>

--- a/test/importers/html2jcr/fixtures/block.expected.xml
+++ b/test/importers/html2jcr/fixtures/block.expected.xml
@@ -38,5 +38,6 @@
                 </block_2>
             </section_1>
         </root>
+        <image jcr:primaryType="nt:unstructured" fileReference="https://main--xwalk-example--buuhuu.hlx.page/media_134b848c697e9152f269fa3b79696b855040912ba.png?width=1200&amp;format=pjpg&amp;optimize=medium"/>
     </jcr:content>
 </jcr:root>

--- a/test/importers/html2jcr/fixtures/button.expected.xml
+++ b/test/importers/html2jcr/fixtures/button.expected.xml
@@ -9,5 +9,6 @@
                 <button_2 sling:resourceType="core/franklin/components/button/v1/button" jcr:primaryType="nt:unstructured" href="#" text="" title=""/>
             </section>
         </root>
+        <image jcr:primaryType="nt:unstructured" fileReference="https://main--xwalk-example--buuhuu.hlx.page/media_134b848c697e9152f269fa3b79696b855040912ba.png?width=1200&amp;format=pjpg&amp;optimize=medium"/>
     </jcr:content>
 </jcr:root>

--- a/test/importers/html2jcr/fixtures/columns.expected.xml
+++ b/test/importers/html2jcr/fixtures/columns.expected.xml
@@ -31,5 +31,6 @@
                 </columns>
             </section>
         </root>
+        <image jcr:primaryType="nt:unstructured" fileReference="https://main--xwalk-example--buuhuu.hlx.page/media_134b848c697e9152f269fa3b79696b855040912ba.png?width=1200&amp;format=pjpg&amp;optimize=medium"/>
     </jcr:content>
 </jcr:root>

--- a/test/importers/html2jcr/fixtures/components-models.json
+++ b/test/importers/html2jcr/fixtures/components-models.json
@@ -48,6 +48,13 @@
           },
           {
             "component": "text",
+            "name": "og:image",
+            "label": "Page Image",
+            "value": "",
+            "valueType": "string"
+          },
+          {
+            "component": "text",
             "name": "authorTitle",
             "value": "",
             "valueType": "string"

--- a/test/importers/html2jcr/fixtures/headline.expected.xml
+++ b/test/importers/html2jcr/fixtures/headline.expected.xml
@@ -10,5 +10,6 @@
                 <title_3 sling:resourceType="core/franklin/components/title/v1/title" jcr:primaryType="nt:unstructured" jcr:title="Lorem ipsum" type="h5"/>
             </section>
         </root>
+        <image jcr:primaryType="nt:unstructured" fileReference="https://main--xwalk-example--buuhuu.hlx.page/media_134b848c697e9152f269fa3b79696b855040912ba.png?width=1200&amp;format=pjpg&amp;optimize=medium"/>
     </jcr:content>
 </jcr:root>

--- a/test/importers/html2jcr/fixtures/image.expected.xml
+++ b/test/importers/html2jcr/fixtures/image.expected.xml
@@ -7,5 +7,6 @@
                 <image_0 sling:resourceType="core/franklin/components/image/v1/image" jcr:primaryType="nt:unstructured" alt="People sitting in the garden &amp; relaxing" title="Spring time is garden time" fileReference="/content/dam/asset.jpg"/>
             </section>
         </root>
+        <image jcr:primaryType="nt:unstructured" fileReference="https://main--xwalk-example--buuhuu.hlx.page/media_134b848c697e9152f269fa3b79696b855040912ba.png?width=1200&amp;format=pjpg&amp;optimize=medium"/>
     </jcr:content>
 </jcr:root>

--- a/test/importers/html2jcr/fixtures/page-metadata.expected.xml
+++ b/test/importers/html2jcr/fixtures/page-metadata.expected.xml
@@ -2,5 +2,6 @@
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0" jcr:primaryType="cq:Page">
     <jcr:content cq:template="/libs/core/franklin/templates/page" jcr:primaryType="cq:PageContent" sling:resourceType="core/franklin/components/page/v1/page" jcr:title="Test Page &amp; Content" jcr:description="Test description" datetime="2024-04-23T15:53:00.000+02:00" cq:robotsTags="[index,follow]" keywords="[foo,bar,lorem &amp; ipsum]" topics="[one,two,three]" authorTitle="John Doe" abstract="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla eu purus id tellus consequat pharetra. Fusce blandit felis ut dui congue, cursus suscipit est hendrerit." template="salescontent">
         <root jcr:primaryType="nt:unstructured" sling:resourceType="core/franklin/components/root/v1/root"/>
+        <image jcr:primaryType="nt:unstructured" fileReference="/content/dam/asset.jpg"/>
     </jcr:content>
 </jcr:root>

--- a/test/importers/html2jcr/fixtures/page-metadata.html
+++ b/test/importers/html2jcr/fixtures/page-metadata.html
@@ -9,6 +9,7 @@
     <meta name="robots" content="index, follow"/>
     <meta name="keywords" content="foo, bar, lorem & ipsum"/>
     <meta name="topics" content="one, two, three"/>
+    <meta name="og:image" content="/content/dam/asset.jpg"/>
     <meta name="authortitle" content="John Doe"/>
     <meta name="abstract" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla eu purus id tellus consequat pharetra. Fusce blandit felis ut dui congue, cursus suscipit est hendrerit."/>
     <meta property="og:title" content="Test Page">

--- a/test/importers/html2jcr/fixtures/section.expected.xml
+++ b/test/importers/html2jcr/fixtures/section.expected.xml
@@ -12,5 +12,6 @@
                 <text sling:resourceType="core/franklin/components/text/v1/text" jcr:primaryType="nt:unstructured" text="&lt;p>Lorem ipsum&lt;/p>"/>
             </section_1>
         </root>
+        <image jcr:primaryType="nt:unstructured" fileReference="https://main--xwalk-example--buuhuu.hlx.page/media_134b848c697e9152f269fa3b79696b855040912ba.png?width=1200&amp;format=pjpg&amp;optimize=medium"/>
     </jcr:content>
 </jcr:root>

--- a/test/importers/html2jcr/fixtures/text-siblings.expected.xml
+++ b/test/importers/html2jcr/fixtures/text-siblings.expected.xml
@@ -9,5 +9,6 @@
                 <text_1 sling:resourceType="core/franklin/components/text/v1/text" jcr:primaryType="nt:unstructured" text="&lt;p>Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...&lt;br>There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain...&lt;/p>"/>
             </section>
         </root>
+        <image jcr:primaryType="nt:unstructured" fileReference="https://main--xwalk-example--buuhuu.hlx.page/media_134b848c697e9152f269fa3b79696b855040912ba.png?width=1200&amp;format=pjpg&amp;optimize=medium"/>
     </jcr:content>
 </jcr:root>

--- a/test/importers/html2jcr/fixtures/text-simple.expected.xml
+++ b/test/importers/html2jcr/fixtures/text-simple.expected.xml
@@ -6,5 +6,6 @@
                 <text sling:resourceType="core/franklin/components/text/v1/text" jcr:primaryType="nt:unstructured" text="&lt;p>Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...&lt;br>There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain...&lt;/p>"/>
             </section>
         </root>
+        <image jcr:primaryType="nt:unstructured" fileReference="https://main--xwalk-example--buuhuu.hlx.page/media_134b848c697e9152f269fa3b79696b855040912ba.png?width=1200&amp;format=pjpg&amp;optimize=medium"/>
     </jcr:content>
 </jcr:root>


### PR DESCRIPTION
- if the page metadata has an image property, add an image node below the jcr:content node
- adapt the tests

Fixes #27 
